### PR TITLE
align typescript config (target) with node.js version in jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,14 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|scss|svg|png|jpg)$': 'identity-obj-proxy',
   },
+  globals: {
+    'ts-jest': {
+      tsconfig: {
+        // https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
+        lib: ['ES2019'],
+        module: 'commonjs',
+        target: 'ES2019',
+      },
+    },
+  },
 }


### PR DESCRIPTION
Fixed die Warnung:
```
ts-jest[config] (WARN) There is a mismatch between your NodeJs version v12.20.0 and your TypeScript target esnext. This might lead to some unexpected errors when running tests with `ts-jest`. To fix this, you can check https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
```